### PR TITLE
Add poetry publish step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,4 +8,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    steps: []
+    steps:
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          pip install poetry
+          poetry run poetry publish


### PR DESCRIPTION
Apparently GitHub complains if there're no steps in one of the workflos
on every single PR. So let's fix it and add poetry publish step to it.
I'm not sure whether it works or not, but it should be as easy as that
to release new version on PyPI. 8)