### PR TITLE
Add keychain providers along with shell provider

### DIFF
--- a/src/httpie_credential_store/_auth.py
+++ b/src/httpie_credential_store/_auth.py
@@ -1,6 +1,35 @@
 """Various authentication providers for python-requests."""
 
+import collections.abc
 import requests.auth
+
+from ._keychains import get_keychain
+
+
+def get_secret_value(value):
+    if not isinstance(value, collections.abc.Mapping):
+        return value
+
+    keychain = get_keychain(value.pop("keychain"))
+    return keychain.get(**value)
+
+
+class HTTPBasicAuth(requests.auth.HTTPBasicAuth):
+    """Authentication via HTTP Basic scheme."""
+
+    def __init__(self, username, password):
+        super(HTTPBasicAuth, self).__init__(
+            username, get_secret_value(password)
+        )
+
+
+class HTTPDigestAuth(requests.auth.HTTPDigestAuth):
+    """Authentication via HTTP Digest scheme."""
+
+    def __init__(self, username, password):
+        super(HTTPDigestAuth, self).__init__(
+            username, get_secret_value(password)
+        )
 
 
 class HTTPHeaderAuth(requests.auth.AuthBase):
@@ -8,7 +37,7 @@ class HTTPHeaderAuth(requests.auth.AuthBase):
 
     def __init__(self, name, value):
         self._header_name = name
-        self._header_value = value
+        self._header_value = get_secret_value(value)
 
     def __call__(self, request):
         request.headers[self._header_name] = self._header_value
@@ -19,13 +48,15 @@ class HTTPTokenAuth(HTTPHeaderAuth):
     """Authentication via token."""
 
     def __init__(self, token, scheme="Bearer"):
+        token = get_secret_value(token)
+
         super(HTTPTokenAuth, self).__init__(
             "Authorization", f"{scheme} {token}"
         )
 
 
 AUTH = {
-    "basic": requests.auth.HTTPBasicAuth,
+    "basic": HTTPBasicAuth,
     "digest": requests.auth.HTTPDigestAuth,
     "header": HTTPHeaderAuth,
     "token": HTTPTokenAuth,

--- a/src/httpie_credential_store/_keychains.py
+++ b/src/httpie_credential_store/_keychains.py
@@ -1,0 +1,36 @@
+"""Keychain providers to read secrets from."""
+
+import abc
+import subprocess
+
+
+class KeychainProvider(metaclass=abc.ABCMeta):
+    """Keychain provider interface."""
+
+    @property
+    @abc.abstractmethod
+    def name(self):
+        """Provider/implementation name."""
+
+    @abc.abstractmethod
+    def get(self, **kwargs):
+        """Return value from keychain."""
+
+
+class ShellKeychain(KeychainProvider):
+    """Executes arbitrary shell command to retrieve a secret."""
+
+    name = "shell"
+
+    def get(self, command):
+        return subprocess.check_output(command, shell=True).decode("UTF-8")
+
+
+_PROVIDERS = {
+    provider_cls.name: provider_cls
+    for provider_cls in KeychainProvider.__subclasses__()
+}
+
+
+def get_keychain(provider):
+    return _PROVIDERS[provider]()

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -176,6 +176,41 @@ def test_creds_auth_basic(httpie_run, set_credentials, creds_auth_type):
 
 
 @responses.activate
+def test_creds_auth_basic_keychain(
+    httpie_run, set_credentials, creds_auth_type, tmpdir, httpie_stderr
+):
+    """The plugin retrieves secrets from keychain for HTTP basic auth."""
+
+    secrettxt = tmpdir.join("secret.txt")
+    secrettxt.write_text("p@ss", encoding="UTF-8")
+
+    set_credentials(
+        [
+            {
+                "url": "http://example.com",
+                "auth": [
+                    {
+                        "type": "basic",
+                        "username": "user",
+                        "password": {
+                            "keychain": "shell",
+                            "command": f"cat {secrettxt.strpath}",
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+    httpie_run(["-A", creds_auth_type, "http://example.com"])
+
+    assert len(responses.calls) == 1
+    request = responses.calls[0].request
+
+    assert request.url == "http://example.com/"
+    assert request.headers["Authorization"] == "Basic dXNlcjpwQHNz"
+
+
+@responses.activate
 def test_creds_auth_digest(httpie_run, set_credentials, creds_auth_type):
     """The plugin works for HTTP digest auth."""
 
@@ -285,6 +320,40 @@ def test_creds_auth_token_scheme(httpie_run, set_credentials, creds_auth_type):
 
 
 @responses.activate
+def test_creds_auth_token_keychain(
+    httpie_run, set_credentials, creds_auth_type, tmpdir
+):
+    """The plugin retrieves secrets from keychain for HTTP token auth."""
+
+    secrettxt = tmpdir.join("secret.txt")
+    secrettxt.write_text("token-can-be-anything", encoding="UTF-8")
+
+    set_credentials(
+        [
+            {
+                "url": "http://example.com",
+                "auth": [
+                    {
+                        "type": "token",
+                        "token": {
+                            "keychain": "shell",
+                            "command": f"cat {secrettxt.strpath}",
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+    httpie_run(["-A", creds_auth_type, "http://example.com"])
+
+    assert len(responses.calls) == 1
+    request = responses.calls[0].request
+
+    assert request.url == "http://example.com/"
+    assert request.headers["Authorization"] == "Bearer token-can-be-anything"
+
+
+@responses.activate
 def test_creds_auth_header(httpie_run, set_credentials, creds_auth_type):
     """The plugin works for HTTP header auth."""
 
@@ -297,6 +366,41 @@ def test_creds_auth_header(httpie_run, set_credentials, creds_auth_type):
                         "type": "header",
                         "name": "X-Auth",
                         "value": "value-can-be-anything",
+                    }
+                ],
+            }
+        ]
+    )
+    httpie_run(["-A", creds_auth_type, "http://example.com"])
+
+    assert len(responses.calls) == 1
+    request = responses.calls[0].request
+
+    assert request.url == "http://example.com/"
+    assert request.headers["X-Auth"] == "value-can-be-anything"
+
+
+@responses.activate
+def test_creds_auth_header_keychain(
+    httpie_run, set_credentials, creds_auth_type, tmpdir
+):
+    """The plugin retrieves secrets from keychain for HTTP header auth."""
+
+    secrettxt = tmpdir.join("secret.txt")
+    secrettxt.write_text("value-can-be-anything", encoding="UTF-8")
+
+    set_credentials(
+        [
+            {
+                "url": "http://example.com",
+                "auth": [
+                    {
+                        "type": "header",
+                        "name": "X-Auth",
+                        "value": {
+                            "keychain": "shell",
+                            "command": f"cat {secrettxt.strpath}",
+                        },
                     }
                 ],
             }
@@ -379,6 +483,51 @@ def test_creds_auth_combo_header_header(
     assert request.url == "http://example.com/"
     assert request.headers["X-Secret"] == "secret-can-be-anything"
     assert request.headers["X-Auth"] == "auth-can-be-anything"
+
+
+@responses.activate
+def test_creds_auth_combo_token_header_keychain(
+    httpie_run, set_credentials, creds_auth_type, tmpdir
+):
+    """The plugin retrieves secrets from keychains for combination of auths."""
+
+    tokentxt, secrettxt = tmpdir.join("token.txt"), tmpdir.join("secret.txt")
+    tokentxt.write_text("token-can-be-anything", encoding="UTF-8")
+    secrettxt.write_text("secret-can-be-anything", encoding="UTF-8")
+
+    set_credentials(
+        [
+            {
+                "url": "http://example.com",
+                "auth": [
+                    {
+                        "type": "token",
+                        "token": {
+                            "keychain": "shell",
+                            "command": f"cat {tokentxt.strpath}",
+                        },
+                        "scheme": "JWT",
+                    },
+                    {
+                        "type": "header",
+                        "name": "X-Auth",
+                        "value": {
+                            "keychain": "shell",
+                            "command": f"cat {secrettxt.strpath}",
+                        },
+                    },
+                ],
+            }
+        ]
+    )
+    httpie_run(["-A", creds_auth_type, "http://example.com"])
+
+    assert len(responses.calls) == 1
+    request = responses.calls[0].request
+
+    assert request.url == "http://example.com/"
+    assert request.headers["Authorization"] == "JWT token-can-be-anything"
+    assert request.headers["X-Auth"] == "secret-can-be-anything"
 
 
 @responses.activate


### PR DESCRIPTION
Keychain providers are designed to provide a bridge between this plugin
and user's secret storage. It may be system keychain/keyring service or
some password manager; we don't care much as long as it can be invoked
and securely return a secret.

Shell provider is the most basic provider that does nothing securily.
However, this is an ultimate bridge that can be used with any custom
script or CLI program. Later on, we will implement system keychain
provider.