### PR TITLE
Add 'system' keychain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ keywords = ["httpie", "credential", "store", "keychain", "plugin", "auth"]
 [tool.poetry.dependencies]
 python = "^3.6"
 httpie = "^1.0"
+keyring = "^19.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/src/httpie_credential_store/_keychains.py
+++ b/src/httpie_credential_store/_keychains.py
@@ -3,6 +3,8 @@
 import abc
 import subprocess
 
+import keyring
+
 
 class KeychainProvider(metaclass=abc.ABCMeta):
     """Keychain provider interface."""
@@ -22,8 +24,29 @@ class ShellKeychain(KeychainProvider):
 
     name = "shell"
 
-    def get(self, command):
-        return subprocess.check_output(command, shell=True).decode("UTF-8")
+    def get(self, *, command):
+        try:
+            return subprocess.check_output(command, shell=True).decode("UTF-8")
+        except subprocess.CalledProcessError as exc:
+            raise LookupError(f"No secret found: {exc}")
+
+
+class SystemKeychain(KeychainProvider):
+    """Retrieve secret from the system's keychain."""
+
+    name = "system"
+
+    def __init__(self):
+        self._keyring = keyring.get_keyring()
+
+    def get(self, *, service, username):
+        secret = self._keyring.get_password(service, username)
+        if not secret:
+            raise LookupError(
+                f"No secret found for '{service}' service and '{username}' "
+                f"username in '{self.name}' keychain."
+            )
+        return secret
 
 
 _PROVIDERS = {

--- a/tests/keychains/test_shell.py
+++ b/tests/keychains/test_shell.py
@@ -1,0 +1,57 @@
+"""Tests shell keychain provider."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def testkeychain():
+    """Keychain instance under test."""
+
+    # For the same reasons as in tests/test_credential_store.py, all imports
+    # that trigger HTTPie importing must be postponed till one of our fixtures
+    # is evaluated and patched a path to HTTPie configuration.
+    from httpie_credential_store import _keychains
+
+    return _keychains.ShellKeychain()
+
+
+def test_secret_retrieved(testkeychain, tmpdir):
+    """The keychain returns stored secret, no bullshit."""
+
+    secrettxt = tmpdir.join("secret.txt")
+    secrettxt.write_text("p@ss", encoding="UTF-8")
+    assert testkeychain.get(command=f"cat {secrettxt.strpath}") == "p@ss"
+
+
+def test_secret_retrieved_pipe(testkeychain, tmpdir):
+    """The keychain returns stored secret even when pipes are used."""
+
+    secrettxt = tmpdir.join("secret.txt")
+    secrettxt.write_text("p@ss\nextra", encoding="UTF-8")
+
+    command = fr"cat {secrettxt.strpath} | head -n 1 | tr -d {os.linesep!r}"
+    assert testkeychain.get(command=command) == "p@ss"
+
+
+def test_secret_not_found(testkeychain, tmpdir):
+    """LookupError is raised when no secrets are found in the keychain."""
+
+    secrettxt = tmpdir.join("secret.txt")
+
+    with pytest.raises(LookupError) as excinfo:
+        testkeychain.get(command=f"cat {secrettxt.strpath}")
+
+    assert str(excinfo.value) == (
+        f"No secret found: Command 'cat {secrettxt.strpath}' returned "
+        f"non-zero exit status 1."
+    )
+
+
+@pytest.mark.parametrize(
+    ["args", "kwargs"], [pytest.param(["echo p@ss"], {}, id="args")]
+)
+def test_keywords_only_arguments(testkeychain, args, kwargs):
+    with pytest.raises(TypeError):
+        testkeychain.get(*args, **kwargs)

--- a/tests/keychains/test_system.py
+++ b/tests/keychains/test_system.py
@@ -1,0 +1,72 @@
+"""Tests system keychain provider."""
+
+import keyring
+import pytest
+
+
+class _InmemoryKeyring(keyring.backend.KeyringBackend):
+    """Keyring backend that stores secrets in-memory."""
+
+    def __init__(self):
+        self._keyring = {}
+
+    def get_password(self, service, username):
+        return self._keyring.get((service, username))
+
+    def set_password(self, service, username, password):
+        self._keyring[(service, username)] = password
+
+
+@pytest.fixture(scope="function", autouse=True)
+def keyring_backend():
+    """Temporary set in-memory keyring as current backend."""
+
+    prev_backend = keyring.get_keyring()
+    keyring.set_keyring(_InmemoryKeyring())
+    yield keyring.get_keyring()
+    keyring.set_keyring(prev_backend)
+
+
+@pytest.fixture(scope="function")
+def testkeychain():
+    """Keychain instance under test."""
+
+    # For the same reasons as in tests/test_credential_store.py, all imports
+    # that trigger HTTPie importing must be postponed till one of our fixtures
+    # is evaluated and patched a path to HTTPie configuration.
+    from httpie_credential_store import _keychains
+
+    return _keychains.SystemKeychain()
+
+
+def test_secret_retrieved(testkeychain, keyring_backend):
+    """The keychain returns stored secret, no bullshit."""
+
+    keyring_backend.set_password("testsvc", "testuser", "p@ss")
+    assert testkeychain.get(service="testsvc", username="testuser") == "p@ss"
+
+
+def test_secret_not_found(testkeychain):
+    """LookupError is raised when no secrets are found in the keychain."""
+
+    with pytest.raises(LookupError) as excinfo:
+        assert testkeychain.get(service="testsvc", username="testuser")
+
+    assert str(excinfo.value) == (
+        "No secret found for 'testsvc' service and 'testuser' username "
+        "in 'system' keychain."
+    )
+
+
+@pytest.mark.parametrize(
+    ["args", "kwargs"],
+    [
+        pytest.param(["testsvc", "testuser"], {}, id="args"),
+        pytest.param(["testsvc"], {"username": "testuser"}, id="args-kwargs"),
+    ],
+)
+def test_keywords_only_arguments(testkeychain, keyring_backend, args, kwargs):
+    keyring_backend.set_password("testsvc", "testuser", "p@ss")
+
+    with pytest.raises(TypeError):
+        testkeychain.get(*args, **kwargs)

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -153,7 +153,9 @@ def test_creds_auth_deactivated_by_default(httpie_run):
 
 
 @responses.activate
-def test_creds_auth_basic(httpie_run, set_credentials, creds_auth_type):
+def test_creds_auth_basic(
+    httpie_run, set_credentials, creds_auth_type, httpie_stderr
+):
     """The plugin works for HTTP basic auth."""
 
     set_credentials(


### PR DESCRIPTION
System keychain integrates well with your system's primary keychain. For instance, on GNOME, it's `gnome-keyring`, on KDE - `kwallet`, on macOS - `macOS keychain`, etc. It's safe to store your secrets in system keychain because they are usually stored encrypted and decrypted on user log-in (hence no user action required).

Resolves: #5 