### PR TITLE
Refactor authentication providers

### DIFF
--- a/src/httpie_credential_store/_auth.py
+++ b/src/httpie_credential_store/_auth.py
@@ -1,12 +1,16 @@
 """Various authentication providers for python-requests."""
 
+import abc
 import collections.abc
+
 import requests.auth
 
 from ._keychain import get_keychain
 
 
-def get_secret_value(value):
+def get_secret(value):
+    """Retrieve and return secret."""
+
     if not isinstance(value, collections.abc.Mapping):
         return value
 
@@ -14,65 +18,87 @@ def get_secret_value(value):
     return keychain.get(**value)
 
 
-class HTTPBasicAuth(requests.auth.HTTPBasicAuth):
+class AuthProvider(metaclass=abc.ABCMeta):
+    """Auth provider interface."""
+
+    @property
+    @abc.abstractmethod
+    def name(self):
+        """Provider/implementation name."""
+
+    @abc.abstractmethod
+    def __call__(self, request):
+        """Attach authentication to a given request."""
+
+
+class HTTPBasicAuth(requests.auth.HTTPBasicAuth, AuthProvider):
     """Authentication via HTTP Basic scheme."""
 
-    def __init__(self, username, password):
-        super(HTTPBasicAuth, self).__init__(
-            username, get_secret_value(password)
-        )
+    name = "basic"
+
+    def __init__(self, *, username, password):
+        super(HTTPBasicAuth, self).__init__(username, get_secret(password))
 
 
-class HTTPDigestAuth(requests.auth.HTTPDigestAuth):
+class HTTPDigestAuth(requests.auth.HTTPDigestAuth, AuthProvider):
     """Authentication via HTTP Digest scheme."""
 
-    def __init__(self, username, password):
-        super(HTTPDigestAuth, self).__init__(
-            username, get_secret_value(password)
-        )
+    name = "digest"
+
+    def __init__(self, *, username, password):
+        super(HTTPDigestAuth, self).__init__(username, get_secret(password))
 
 
-class HTTPHeaderAuth(requests.auth.AuthBase):
+class HTTPHeaderAuth(requests.auth.AuthBase, AuthProvider):
     """Authentication via custom HTTP header."""
 
-    def __init__(self, name, value):
-        self._header_name = name
-        self._header_value = get_secret_value(value)
+    name = "header"
+
+    def __init__(self, *, name, value):
+        self._name = name
+        self._value = get_secret(value)
 
     def __call__(self, request):
-        request.headers[self._header_name] = self._header_value
+        request.headers[self._name] = self._value
         return request
 
 
-class HTTPTokenAuth(HTTPHeaderAuth):
+class HTTPTokenAuth(requests.auth.AuthBase, AuthProvider):
     """Authentication via token."""
 
-    def __init__(self, token, scheme="Bearer"):
-        token = get_secret_value(token)
+    name = "token"
 
-        super(HTTPTokenAuth, self).__init__(
-            "Authorization", f"{scheme} {token}"
-        )
+    def __init__(self, *, token, scheme="Bearer"):
+        self._scheme = scheme
+        self._token = get_secret(token)
+
+    def __call__(self, request):
+        request.headers["Authorization"] = f"{self._scheme} {self._token}"
+        return request
 
 
-AUTH = {
-    "basic": HTTPBasicAuth,
-    "digest": requests.auth.HTTPDigestAuth,
-    "header": HTTPHeaderAuth,
-    "token": HTTPTokenAuth,
+class HTTPMultipleAuth(requests.auth.AuthBase, AuthProvider):
+    """Authentication via multiple providers simultaneously."""
+
+    name = "multiple"
+
+    def __init__(self, *, providers):
+        self._providers = [
+            get_auth(provider.pop("provider"), **provider)
+            for provider in providers
+        ]
+
+    def __call__(self, request):
+        for provider in self._providers:
+            request = provider(request)
+        return request
+
+
+_PROVIDERS = {
+    provider_cls.name: provider_cls
+    for provider_cls in AuthProvider.__subclasses__()
 }
 
 
-def get_auth(keys):
-    """Returns auth provider for requests."""
-
-    def set_auth(request):
-        for key in keys:
-            auth = key.copy()
-            auth.pop("id", None)
-            type = auth.pop("type")
-            auth = AUTH[type](**auth)
-            request = auth(request)
-        return request
-
-    return set_auth
+def get_auth(provider, **kwargs):
+    return _PROVIDERS[provider](**kwargs)

--- a/src/httpie_credential_store/_plugin.py
+++ b/src/httpie_credential_store/_plugin.py
@@ -3,7 +3,6 @@
 import requests
 import httpie.plugins
 
-from ._auth import get_auth
 from ._store import get_credential_store
 
 
@@ -17,7 +16,7 @@ class CredentialStoreAuthPlugin(httpie.plugins.AuthPlugin):
     """
 
     name = "credential-store"
-    description = "Retrieve and set auth information based on URL."
+    description = "Retrieve & attach authentication to ongoing HTTP request."
 
     auth_type = (
         "credential-store"  # use plugin by passing '-A credential-store'
@@ -31,9 +30,8 @@ class CredentialStoreAuthPlugin(httpie.plugins.AuthPlugin):
         class CredentialStoreAuth(requests.auth.AuthBase):
             def __call__(self, request):
                 store = get_credential_store("credentials.json")
-                auth = store.lookup(request.url, credential_id)
-                set_auth = get_auth(auth)
-                return set_auth(request)
+                auth = store.get_auth_for(request.url, credential_id)
+                return auth(request)
 
         return CredentialStoreAuth()
 

--- a/src/httpie_credential_store/_store.py
+++ b/src/httpie_credential_store/_store.py
@@ -9,6 +9,8 @@ import sys
 
 import httpie.config
 
+from ._auth import get_auth
+
 
 class CredentialStore(object):
     """Credential store, manages your credentials."""
@@ -16,12 +18,16 @@ class CredentialStore(object):
     def __init__(self, credentials):
         self._credentials = credentials
 
-    def lookup(self, url, credential_id=None):
+    def get_auth_for(self, url, credential_id=None):
+        """Return requests' auth instance."""
+
         for credential in self._credentials:
             if re.search(credential["url"], url):
                 if credential_id and credential.get("id") != credential_id:
                     continue
-                return credential["auth"]
+
+                auth = credential["auth"].copy()
+                return get_auth(auth.pop("provider"), **auth)
 
         message = f"No credentials found for a given URL: '{url}'"
         if credential_id:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -142,9 +142,11 @@ def test_creds_auth_basic(
         [
             {
                 "url": "http://example.com",
-                "auth": [
-                    {"type": "basic", "username": "user", "password": "p@ss"}
-                ],
+                "auth": {
+                    "provider": "basic",
+                    "username": "user",
+                    "password": "p@ss",
+                },
             }
         ]
     )
@@ -170,16 +172,14 @@ def test_creds_auth_basic_keychain(
         [
             {
                 "url": "http://example.com",
-                "auth": [
-                    {
-                        "type": "basic",
-                        "username": "user",
-                        "password": {
-                            "keychain": "shell",
-                            "command": f"cat {secrettxt.strpath}",
-                        },
-                    }
-                ],
+                "auth": {
+                    "provider": "basic",
+                    "username": "user",
+                    "password": {
+                        "keychain": "shell",
+                        "command": f"cat {secrettxt.strpath}",
+                    },
+                },
             }
         ]
     )
@@ -217,9 +217,11 @@ def test_creds_auth_digest(httpie_run, set_credentials, creds_auth_type):
         [
             {
                 "url": "http://example.com",
-                "auth": [
-                    {"type": "digest", "username": "user", "password": "p@ss"}
-                ],
+                "auth": {
+                    "provider": "digest",
+                    "username": "user",
+                    "password": "p@ss",
+                },
             }
         ]
     )
@@ -261,7 +263,10 @@ def test_creds_auth_token(httpie_run, set_credentials, creds_auth_type):
         [
             {
                 "url": "http://example.com",
-                "auth": [{"type": "token", "token": "token-can-be-anything"}],
+                "auth": {
+                    "provider": "token",
+                    "token": "token-can-be-anything",
+                },
             }
         ]
     )
@@ -282,13 +287,11 @@ def test_creds_auth_token_scheme(httpie_run, set_credentials, creds_auth_type):
         [
             {
                 "url": "http://example.com",
-                "auth": [
-                    {
-                        "type": "token",
-                        "token": "token-can-be-anything",
-                        "scheme": "JWT",
-                    }
-                ],
+                "auth": {
+                    "provider": "token",
+                    "token": "token-can-be-anything",
+                    "scheme": "JWT",
+                },
             }
         ]
     )
@@ -314,15 +317,13 @@ def test_creds_auth_token_keychain(
         [
             {
                 "url": "http://example.com",
-                "auth": [
-                    {
-                        "type": "token",
-                        "token": {
-                            "keychain": "shell",
-                            "command": f"cat {secrettxt.strpath}",
-                        },
-                    }
-                ],
+                "auth": {
+                    "provider": "token",
+                    "token": {
+                        "keychain": "shell",
+                        "command": f"cat {secrettxt.strpath}",
+                    },
+                },
             }
         ]
     )
@@ -343,13 +344,11 @@ def test_creds_auth_header(httpie_run, set_credentials, creds_auth_type):
         [
             {
                 "url": "http://example.com",
-                "auth": [
-                    {
-                        "type": "header",
-                        "name": "X-Auth",
-                        "value": "value-can-be-anything",
-                    }
-                ],
+                "auth": {
+                    "provider": "header",
+                    "name": "X-Auth",
+                    "value": "value-can-be-anything",
+                },
             }
         ]
     )
@@ -375,16 +374,14 @@ def test_creds_auth_header_keychain(
         [
             {
                 "url": "http://example.com",
-                "auth": [
-                    {
-                        "type": "header",
-                        "name": "X-Auth",
-                        "value": {
-                            "keychain": "shell",
-                            "command": f"cat {secrettxt.strpath}",
-                        },
-                    }
-                ],
+                "auth": {
+                    "provider": "header",
+                    "name": "X-Auth",
+                    "value": {
+                        "keychain": "shell",
+                        "command": f"cat {secrettxt.strpath}",
+                    },
+                },
             }
         ]
     )
@@ -398,27 +395,30 @@ def test_creds_auth_header_keychain(
 
 
 @responses.activate
-def test_creds_auth_combo_token_header(
+def test_creds_auth_multiple_token_header(
     httpie_run, set_credentials, creds_auth_type
 ):
-    """The plugin works for combination of auths."""
+    """The plugin works for multiple auths."""
 
     set_credentials(
         [
             {
                 "url": "http://example.com",
-                "auth": [
-                    {
-                        "type": "token",
-                        "token": "token-can-be-anything",
-                        "scheme": "JWT",
-                    },
-                    {
-                        "type": "header",
-                        "name": "X-Auth",
-                        "value": "value-can-be-anything",
-                    },
-                ],
+                "auth": {
+                    "provider": "multiple",
+                    "providers": [
+                        {
+                            "provider": "token",
+                            "token": "token-can-be-anything",
+                            "scheme": "JWT",
+                        },
+                        {
+                            "provider": "header",
+                            "name": "X-Auth",
+                            "value": "value-can-be-anything",
+                        },
+                    ],
+                },
             }
         ]
     )
@@ -433,7 +433,7 @@ def test_creds_auth_combo_token_header(
 
 
 @responses.activate
-def test_creds_auth_combo_header_header(
+def test_creds_auth_multiple_header_header(
     httpie_run, set_credentials, creds_auth_type
 ):
     """The plugin supports usage of the same auth provider twice."""
@@ -442,18 +442,21 @@ def test_creds_auth_combo_header_header(
         [
             {
                 "url": "http://example.com",
-                "auth": [
-                    {
-                        "type": "header",
-                        "name": "X-Secret",
-                        "value": "secret-can-be-anything",
-                    },
-                    {
-                        "type": "header",
-                        "name": "X-Auth",
-                        "value": "auth-can-be-anything",
-                    },
-                ],
+                "auth": {
+                    "provider": "multiple",
+                    "providers": [
+                        {
+                            "provider": "header",
+                            "name": "X-Secret",
+                            "value": "secret-can-be-anything",
+                        },
+                        {
+                            "provider": "header",
+                            "name": "X-Auth",
+                            "value": "auth-can-be-anything",
+                        },
+                    ],
+                },
             }
         ]
     )
@@ -468,7 +471,7 @@ def test_creds_auth_combo_header_header(
 
 
 @responses.activate
-def test_creds_auth_combo_token_header_keychain(
+def test_creds_auth_multiple_token_header_keychain(
     httpie_run, set_credentials, creds_auth_type, tmpdir
 ):
     """The plugin retrieves secrets from keychains for combination of auths."""
@@ -481,24 +484,27 @@ def test_creds_auth_combo_token_header_keychain(
         [
             {
                 "url": "http://example.com",
-                "auth": [
-                    {
-                        "type": "token",
-                        "token": {
-                            "keychain": "shell",
-                            "command": f"cat {tokentxt.strpath}",
+                "auth": {
+                    "provider": "multiple",
+                    "providers": [
+                        {
+                            "provider": "token",
+                            "token": {
+                                "keychain": "shell",
+                                "command": f"cat {tokentxt.strpath}",
+                            },
+                            "scheme": "JWT",
                         },
-                        "scheme": "JWT",
-                    },
-                    {
-                        "type": "header",
-                        "name": "X-Auth",
-                        "value": {
-                            "keychain": "shell",
-                            "command": f"cat {secrettxt.strpath}",
+                        {
+                            "provider": "header",
+                            "name": "X-Auth",
+                            "value": {
+                                "keychain": "shell",
+                                "command": f"cat {secrettxt.strpath}",
+                            },
                         },
-                    },
-                ],
+                    ],
+                },
             }
         ]
     )
@@ -517,64 +523,70 @@ def test_creds_auth_combo_token_header_keychain(
     ["auth", "error"],
     [
         pytest.param(
-            {"type": "basic"},
-            r"http: error: TypeError: __init__() missing 2 required positional "
-            r"arguments: 'username' and 'password'",
+            {"provider": "basic"},
+            r"http: error: TypeError: __init__() missing 2 required "
+            r"keyword-only arguments: 'username' and 'password'",
             id="basic-both",
         ),
         pytest.param(
-            {"type": "basic", "username": "user"},
-            r"http: error: TypeError: __init__() missing 1 required positional "
-            r"argument: 'password'",
-            id="basic-both",
+            {"provider": "basic", "username": "user"},
+            r"http: error: TypeError: __init__() missing 1 required "
+            r"keyword-only argument: 'password'",
+            id="basic-passowrd",
         ),
         pytest.param(
-            {"type": "basic", "password": "p@ss"},
-            r"http: error: TypeError: __init__() missing 1 required positional "
-            r"argument: 'username'",
-            id="basic-both",
+            {"provider": "basic", "password": "p@ss"},
+            r"http: error: TypeError: __init__() missing 1 required "
+            r"keyword-only argument: 'username'",
+            id="basic-username",
         ),
         pytest.param(
-            {"type": "digest"},
-            r"http: error: TypeError: __init__() missing 2 required positional "
-            r"arguments: 'username' and 'password'",
+            {"provider": "digest"},
+            r"http: error: TypeError: __init__() missing 2 required "
+            r"keyword-only arguments: 'username' and 'password'",
             id="digest-both",
         ),
         pytest.param(
-            {"type": "digest", "username": "user"},
-            r"http: error: TypeError: __init__() missing 1 required positional "
-            r"argument: 'password'",
-            id="digest-both",
+            {"provider": "digest", "username": "user"},
+            r"http: error: TypeError: __init__() missing 1 required "
+            r"keyword-only argument: 'password'",
+            id="digest-password",
         ),
         pytest.param(
-            {"type": "digest", "password": "p@ss"},
-            r"http: error: TypeError: __init__() missing 1 required positional "
-            r"argument: 'username'",
-            id="digest-both",
+            {"provider": "digest", "password": "p@ss"},
+            r"http: error: TypeError: __init__() missing 1 required "
+            r"keyword-only argument: 'username'",
+            id="digest-username",
         ),
         pytest.param(
-            {"type": "token"},
-            r"http: error: TypeError: __init__() missing 1 required positional "
-            r"argument: 'token'",
+            {"provider": "token"},
+            r"http: error: TypeError: __init__() missing 1 required "
+            r"keyword-only argument: 'token'",
             id="token",
         ),
         pytest.param(
-            {"type": "header"},
-            r"http: error: TypeError: __init__() missing 2 required positional "
-            r"arguments: 'name' and 'value'",
+            {"provider": "header"},
+            r"http: error: TypeError: __init__() missing 2 required "
+            r"keyword-only arguments: 'name' and 'value'",
             id="header-both",
         ),
         pytest.param(
-            {"type": "header", "name": "X-Auth"},
-            r"http: error: TypeError: __init__() missing 1 required positional "
-            r"argument: 'value'",
+            {"provider": "header", "name": "X-Auth"},
+            r"http: error: TypeError: __init__() missing 1 required "
+            r"keyword-only argument: 'value'",
             id="header-value",
         ),
         pytest.param(
-            {"type": "header", "value": "value-can-be-anything"},
-            r"http: error: TypeError: __init__() missing 1 required positional "
-            r"argument: 'name'",
+            {"provider": "header", "value": "value-can-be-anything"},
+            r"http: error: TypeError: __init__() missing 1 required "
+            r"keyword-only argument: 'name'",
             id="header-name",
+        ),
+        pytest.param(
+            {"provider": "multiple"},
+            r"http: error: TypeError: __init__() missing 1 required "
+            r"keyword-only argument: 'providers'",
+            id="multiple",
         ),
     ],
 )
@@ -583,7 +595,7 @@ def test_creds_auth_missing(
 ):
     """The plugin raises error on wrong parameters."""
 
-    set_credentials([{"url": "http://example.com", "auth": [auth]}])
+    set_credentials([{"url": "http://example.com", "auth": auth}])
     httpie_run(["-A", creds_auth_type, "http://example.com"])
 
     assert len(responses.calls) == 0
@@ -656,7 +668,10 @@ def test_creds_lookup_regexp(
         [
             {
                 "url": regexp,
-                "auth": [{"type": "token", "token": "token-can-be-anything"}],
+                "auth": {
+                    "provider": "token",
+                    "token": "token-can-be-anything",
+                },
             }
         ]
     )
@@ -679,13 +694,18 @@ def test_creds_lookup_1st_matched_wins(
         [
             {
                 "url": "yoda.ua",
-                "auth": [{"type": "token", "token": "token-can-be-anything"}],
+                "auth": {
+                    "provider": "token",
+                    "token": "token-can-be-anything",
+                },
             },
             {
                 "url": "yoda.ua/v2",
-                "auth": [
-                    {"type": "basic", "username": "user", "password": "p@ss"}
-                ],
+                "auth": {
+                    "provider": "basic",
+                    "username": "user",
+                    "password": "p@ss",
+                },
             },
         ]
     )
@@ -711,13 +731,18 @@ def test_creds_lookup_many_credentials(
         [
             {
                 "url": "yoda.ua",
-                "auth": [{"type": "token", "token": "token-can-be-anything"}],
+                "auth": {
+                    "provider": "token",
+                    "token": "token-can-be-anything",
+                },
             },
             {
                 "url": "http://skywalker.com",
-                "auth": [
-                    {"type": "basic", "username": "user", "password": "p@ss"}
-                ],
+                "auth": {
+                    "provider": "basic",
+                    "username": "user",
+                    "password": "p@ss",
+                },
             },
         ]
     )
@@ -762,7 +787,10 @@ def test_creds_lookup_error(
         [
             {
                 "url": regexp,
-                "auth": [{"type": "token", "token": "token-can-be-anything"}],
+                "auth": {
+                    "provider": "token",
+                    "token": "token-can-be-anything",
+                },
             }
         ]
     )
@@ -782,12 +810,12 @@ def test_creds_lookup_by_id(httpie_run, set_credentials):
         [
             {
                 "url": "yoda.ua",
-                "auth": [{"type": "token", "token": "i-am-yoda"}],
+                "auth": {"provider": "token", "token": "i-am-yoda"},
             },
             {
                 "id": "luke",
                 "url": "yoda.ua",
-                "auth": [{"type": "token", "token": "i-am-skywalker"}],
+                "auth": {"provider": "token", "token": "i-am-skywalker"},
             },
         ]
     )
@@ -817,12 +845,12 @@ def test_creds_lookup_by_id_error(
             {
                 "id": "yoda",
                 "url": "yoda.ua",
-                "auth": [{"type": "token", "token": "i-am-yoda"}],
+                "auth": {"provider": "token", "token": "i-am-yoda"},
             },
             {
                 "id": "luke",
                 "url": "yoda.ua",
-                "auth": [{"type": "token", "token": "i-am-skywalker"}],
+                "auth": {"provider": "token", "token": "i-am-skywalker"},
             },
         ]
     )
@@ -859,9 +887,11 @@ def test_creds_permissions_safe(
         [
             {
                 "url": "http://example.com",
-                "auth": [
-                    {"type": "basic", "username": "user", "password": "p@ss"}
-                ],
+                "auth": {
+                    "provider": "basic",
+                    "username": "user",
+                    "password": "p@ss",
+                },
             }
         ],
         mode=mode,
@@ -908,7 +938,7 @@ def test_creds_permissions_unsafe(
 ):
     """The plugin complains if credentials file has unsafe permissions."""
 
-    set_credentials([{"url": "http://example.com", "auth": []}], mode=mode)
+    set_credentials([{"url": "http://example.com", "auth": {}}], mode=mode)
     httpie_run(["-A", creds_auth_type, "http://example.com"])
 
     assert httpie_stderr.getvalue().strip() == (
@@ -940,7 +970,7 @@ def test_creds_permissions_not_enough(
 ):
     """The plugin complains if credentials file has unsafe permissions."""
 
-    set_credentials([{"url": "http://example.com", "auth": []}], mode=mode)
+    set_credentials([{"url": "http://example.com", "auth": {}}], mode=mode)
     httpie_run(["-A", creds_auth_type, "http://example.com"])
 
     assert httpie_stderr.getvalue().strip() == (


### PR DESCRIPTION
Couple of this have been done in this commit related to auth providers
and the way we deal with them:

 * All auth providers implement AuthProvider interface.
 * All auth providers receive keyword-only arguments.
 * Credential store now returns auth provider, not dictionary.

This lays down a good foundation for further improvements and extension.