### PR TITLE
Add 'password-store' keychain provider

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Run pre-commit
-        run: |
-          pip install tox
-          tox -e pre-commit
+        run: pip install tox && tox -e pre-commit
 
   pytest:
     strategy:
@@ -27,10 +25,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Install Ubuntu dependencies
+      run: sudo apt install pass gnupg
+      if: matrix.os == 'ubuntu-latest'
+
+    - name: Install macOS dependencies
+      run: brew install pass gnupg
+      if: matrix.os == 'macos-latest'
+
     - name: Run pytest
       run: |
         pip install tox

--- a/src/httpie_credential_store/_keychain.py
+++ b/src/httpie_credential_store/_keychain.py
@@ -31,6 +31,23 @@ class ShellKeychain(KeychainProvider):
             raise LookupError(f"No secret found: {exc}")
 
 
+class PasswordStoreKeychain(ShellKeychain):
+    """Retrieve secret from password-store."""
+
+    name = "password-store"
+
+    def get(self, *, name):
+        try:
+            # password-store may store securely extra information along with a
+            # password. Nevertheless, a password is always a first line.
+            text = super(PasswordStoreKeychain, self).get(
+                command=f"pass {name}"
+            )
+            return text.splitlines()[0]
+        except LookupError:
+            raise LookupError(f"password-store: no secret found: '{name}'")
+
+
 class SystemKeychain(KeychainProvider):
     """Retrieve secret from the system's keychain."""
 

--- a/tests/test_keychain_password_store.py
+++ b/tests/test_keychain_password_store.py
@@ -1,0 +1,116 @@
+"""Tests password-store keychain provider."""
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+import py
+import pytest
+
+
+_is_windows = sys.platform == "win32"
+_is_macos = sys.platform == "darwin"
+
+
+# On Windows, password-store is only supported through Cygwin. There's no much
+# sense even to try make these tests green on Windows because I doubt there
+# will ever be password-store users on that operating system.
+pytestmark = pytest.mark.skipif(
+    _is_windows, reason="password-store is not supported on windows",
+)
+
+
+if _is_macos:
+    # Unfortunately, when 'gpg' is ran on macOS with GNUPGHOME set to a
+    # temporary directory and generate-key template pointed to a file in
+    # temporary directory too, it complains about using too long names.  It's
+    # not clear why 'gpg' complains about too long names, but it's clear that
+    # built-in 'tmpdir' fixture produces too long names. That's why on macOS we
+    # override 'tmpdir' fixture to return much shorter path to a temporary
+    # directory.
+    @pytest.fixture(scope="function")
+    def tmpdir():
+        with tempfile.TemporaryDirectory() as path:
+            yield py.path.local(path)
+
+
+@pytest.fixture(scope="function")
+def gpg_key_id(monkeypatch, tmpdir):
+    """Return a Key ID of just generated GPG key."""
+
+    gpghome = tmpdir.join(".gnupg")
+    gpgtemplate = tmpdir.join("gpg-template")
+
+    monkeypatch.setitem(os.environ, "GNUPGHOME", gpghome.strpath)
+    gpgtemplate.write_text(
+        textwrap.dedent(
+            """
+                %no-protection
+                Key-Type: default
+                Subkey-Type: default
+                Name-Real: Test
+                Name-Email: test@test
+                Expire-Date: 0
+                %commit
+            """
+        ),
+        encoding="UTF-8",
+    )
+
+    report = subprocess.check_output(
+        f"gpg --batch --generate-key {gpgtemplate}",
+        shell=True,
+        stderr=subprocess.STDOUT,
+    ).decode("UTF-8")
+
+    for line in report.splitlines():
+        if line.startswith("gpg: key "):
+            return line.split()[2]
+
+    raise RuntimeError("cannot generate a GPG key")
+
+
+@pytest.fixture(scope="function", autouse=True)
+def password_store_dir(monkeypatch, tmpdir):
+    """Set password-store home directory to a temporary one."""
+
+    passstore = tmpdir.join(".password-store")
+    monkeypatch.setitem(
+        os.environ, "PASSWORD_STORE_DIR", passstore.strpath,
+    )
+    return passstore.strpath
+
+
+@pytest.fixture(scope="function")
+def testkeychain():
+    """Keychain instance under test."""
+
+    # For the same reasons as in tests/test_plugin.py, all imports that trigger
+    # HTTPie importing must be postponed till one of our fixtures is evaluated
+    # and patched a path to HTTPie configuration.
+    from httpie_credential_store import _keychain
+
+    return _keychain.PasswordStoreKeychain()
+
+
+def test_secret_retrieved(testkeychain, gpg_key_id):
+    """The keychain returns stored secret, no bullshit."""
+
+    subprocess.run(f"pass init {gpg_key_id}", shell=True)
+    subprocess.run(f"pass generate testservice/testuser 14", shell=True)
+
+    secret = testkeychain.get(name="testservice/testuser")
+    assert len(secret) == 14
+
+
+def test_secret_not_found(testkeychain):
+    """LookupError is raised when no secrets are found in the keychain."""
+
+    with pytest.raises(LookupError) as excinfo:
+        testkeychain.get(name="testservice/testuser")
+
+    assert str(excinfo.value) == (
+        "password-store: no secret found: 'testservice/testuser'"
+    )


### PR DESCRIPTION
Password management should be simple and follow Unix philosophy. With
pass, each password lives inside of a gpg encrypted file whose filename
is the title of the website or resource that requires the password.
These encrypted files may be organized into meaningful folder
hierarchies, copied from computer to computer, and, in general,
manipulated using standard command line file management utilities.

https://www.passwordstore.org/

Resolves #9 