### PR TITLE
Bump HTTPie version to 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ keywords = ["httpie", "credential", "store", "keychain", "plugin", "auth"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-httpie = "^1.0"
-keyring = "^19.2"
+httpie = "^2.0"
+keyring = "^21.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -92,7 +92,7 @@ def httpie_run(httpie_stderr):
         import httpie.core
         import httpie.context
 
-        args.insert(0, "--ignore-stdin")
+        args = ["http", "--ignore-stdin"] + args
         env = httpie.context.Environment(stderr=httpie_stderr)
         return httpie.core.main(args, env=env)
 


### PR DESCRIPTION
HTTPie 2.0 has been released couple of weeks ago. We need to catch up
and ensure we support it. Apparently, due to some internal changes we
our tests have to be updated, yet, it seems previos HTTPie major version
is still supported.