### PR TITLE
Open upper interval of 'keyring' dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "httpie-credential-store"
-version = "3.0.0"
+version = "3.1.0"
 description = "HTTPie: one auth to rule them all!"
 authors = ["Ihor Kalnytskyi <ihor@kalnytskyi.com>"]
 license = "MIT"
@@ -12,7 +12,7 @@ keywords = ["httpie", "credential", "store", "keychain", "plugin", "auth"]
 [tool.poetry.dependencies]
 python = "^3.8"
 httpie = "^3.1"
-keyring = "^23.5"
+keyring = ">= 23.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1"


### PR DESCRIPTION
The `keyring` dependency is not optional and is required. Unfortunately, the way it's defined in `pyproject.toml` today prohibits installation of keyring v24 and above.

Even though it's not recommended to install python CLIs system wide, let's do not bit that restrictive unless absolutely necessary (unsupported version).

Fixes: #22