### PR TITLE
Use Flake8 from GitHub, not GitLab

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,8 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
     hooks:
       - id: flake8
         args: ["--max-line-length=99", "--extend-ignore=E203"]


### PR DESCRIPTION
Some time ago, the Flake8 project has been moved from GitLab to GitHub. This means that pre-commit configuration requires updates since it's broken and prevents any new PRs being merged.