### PR TITLE
Drop Python 3.7; add Python 3.10, 3.11 & 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/ikalnytskyi/httpie-credential-store"
 keywords = ["httpie", "credential", "store", "keychain", "plugin", "auth"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 httpie = "^3.1"
 keyring = "^23.5"
 


### PR DESCRIPTION
Python 3.7 reached its end-of-life some time ago now. Currently, it's impossible to setup the 3.7 on macOS runners. It just makes sense to stop supporting this version now.