### PR TITLE
Add third-party auth plugins support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,9 +113,9 @@ passing ``-a`` argument.
 Authentication providers
 ------------------------
 
-HTTPie Credential Store comes with the following authentication
-providers out of box.
-
+HTTPie Credential Store supports both built-in and third-party HTTPie
+authentication plugins as well as provides few authentication plugins
+on its own.
 
 ``basic``
 .........
@@ -226,6 +226,27 @@ simultaneously. It's something you will (likely) never use.
 where
 
 * ``providers`` is a list of auth providers to use simultaneously
+
+
+``hmac``
+........
+
+The 'HMAC' authentication is not built-in one and requires the ``httpie-hmac``
+plugin to be installed first. Its only purpose here is to serve as an example
+of how to invoke third-party authentication plugins from the credentials store.
+
+.. code:: json
+
+   {
+     "provider": "hmac",
+     "auth": "secret:<HMAC_SECRET>"
+   }
+
+where
+
+* ``auth`` is a string with authentication payload passed that is normally
+  passed by a user via ``--auth``/``-a`` to HTTPie; each authentication plugin
+  may or may not require one
 
 
 Keychain providers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ optional = true
 pytest = "^7.1"
 responses = "^0.20"
 pytest-github-actions-annotate-failures = "*"
+httpie-hmac = "*"
 
 [tool.poetry.plugins."httpie.plugins.auth.v1"]
 credential-store = "httpie_credential_store:CredentialStoreAuthPlugin"


### PR DESCRIPTION
The HTTPie ecosystem has myriads of third-party authentication plugins. Even though they ain't as widespread as core ones, I see a huge advantage if we can support those plugins too.

This patch adds support of third-party authentication plugins by retrieving a proper authentication plugin via HTTPie's plugin manager, instead of reimplementing authentication code for core plugins in this project source tree.

There's another benefits of using authentication plugins here. According to some HTTPie in-source comments, the HTTP basic auth from requests library has some unicode issues, and those HTTPie mantains its own basic auth implementation. By using authentication plugins directly, we can get advantage of that implementation too.