### PR TITLE
Use plugin via '-A store', deprecate '-A creds'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Usage
 -----
 
 .. note:: Please, do not forget to activate the plugin by invoking
-          ``http`` with ``-A creds`` option.
+          ``http`` with ``-A store`` option.
 
 Once installed, the plugin will look for credentials in the credential
 file. The credential file is stored in HTTPie configuration directory.
@@ -95,19 +95,19 @@ the following credential record:
    ]
 
 Once the credential store is filled, you're ready to use the plugin at
-your will. In order to activate the plugin, you must pass ``-A creds``
-or ``-A credential-store`` to ``http`` executable.
+your will. In order to activate the plugin, you must pass ``-A store``
+to ``http`` executable.
 
 .. code:: bash
 
-   $ http -A creds https://api.github.com
+   $ http -A store https://api.github.com
 
 Optionally, you can provide an ID of the credential record to use by
 passing ``-a`` argument.
 
 .. code:: bash
 
-   $ http -A creds -a bots https://api.github.com
+   $ http -A store -a bots https://api.github.com
 
 
 Authentication providers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ pytest-github-actions-annotate-failures = "*"
 httpie-hmac = "*"
 
 [tool.poetry.plugins."httpie.plugins.auth.v1"]
+store = "httpie_credential_store:StoreAuthPlugin"
 credential-store = "httpie_credential_store:CredentialStoreAuthPlugin"
 creds = "httpie_credential_store:CredsAuthPlugin"
 

--- a/src/httpie_credential_store/__init__.py
+++ b/src/httpie_credential_store/__init__.py
@@ -1,6 +1,6 @@
 """HTTPie Credential Store."""
 
-from ._plugin import CredentialStoreAuthPlugin, CredsAuthPlugin
+from ._plugin import CredentialStoreAuthPlugin, CredsAuthPlugin, StoreAuthPlugin
 
 
-__all__ = ["CredentialStoreAuthPlugin", "CredsAuthPlugin"]
+__all__ = ["StoreAuthPlugin", "CredentialStoreAuthPlugin", "CredsAuthPlugin"]

--- a/src/httpie_credential_store/_plugin.py
+++ b/src/httpie_credential_store/_plugin.py
@@ -6,7 +6,7 @@ import requests
 from ._store import get_credential_store
 
 
-class CredentialStoreAuthPlugin(httpie.plugins.AuthPlugin):
+class StoreAuthPlugin(httpie.plugins.AuthPlugin):
     """Attach authentication to ongoing HTTP request.
 
     Usage::
@@ -15,10 +15,10 @@ class CredentialStoreAuthPlugin(httpie.plugins.AuthPlugin):
         $ http -A credential-store -a ihor http://example.com/v1/resource
     """
 
-    name = "credential-store"
+    name = "HTTPie Credential Store"
     description = "Retrieve & attach authentication to ongoing HTTP request."
 
-    auth_type = "credential-store"  # use plugin by passing '-A credential-store'
+    auth_type = "store"  # use plugin by passing '-A store'
     auth_require = False  # do not require passing '-a' argument
     auth_parse = False  # do not parse '-a' content
 
@@ -36,7 +36,13 @@ class CredentialStoreAuthPlugin(httpie.plugins.AuthPlugin):
         return CredentialStoreAuth()
 
 
-class CredsAuthPlugin(CredentialStoreAuthPlugin):
-    """Nothing more but a convenient alias."""
+class CredentialStoreAuthPlugin(StoreAuthPlugin):
+    """DEPRECATED: invoke 'store' authentication via '-A credential-store'."""
 
-    auth_type = "creds"  # use plugin by passing '-A creds'
+    auth_type = "credential-store"
+
+
+class CredsAuthPlugin(CredentialStoreAuthPlugin):
+    """DEPRECATED: invoke 'store' authentication via '-A creds'."""
+
+    auth_type = "creds"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -98,7 +98,7 @@ def httpie_run(httpie_stderr):
     return main
 
 
-@pytest.fixture(params=["credential-store", "creds"])
+@pytest.fixture(params=["store", "credential-store", "creds"])
 def creds_auth_type(request):
     """All possible aliases."""
 


### PR DESCRIPTION
The `-A` (`--auth-type`) parameter stands for authentication type, and is essentially the ID of the authentication plugin to invoke. This patch deprecates both `-A credential-store` and `-A creds` usages in favor of newly added `-A store`.

I believe that `store` is both convenient and transparent, so we better deprecate other aliases and remove them in the future in order to prevent polluting plugins namespace.