### PR TITLE
Add tests for 'Bearer' auth type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,24 +158,22 @@ where
 * ``password`` is a password of the authenticating user
 
 
-``token``
-.........
+``bearer``
+..........
 
-The 'Token' HTTP authentication scheme (also called 'Bearer') transmits
-token in the ``Authorization`` HTTP header.
+The 'Bearer' HTTP authentication scheme transmits token in the
+``Authorization`` HTTP header.
 
 .. code:: json
 
    {
      "provider": "token",
-     "token": "t0k3n",
-     "scheme": "JWT"
+     "auth": "t0k3n"
    }
 
 where
 
-* ``token`` is a token of the authenticating user
-* ``scheme`` (optional, default: "Bearer") is an authenticating scheme
+* ``auth`` is a token of the authenticating user
 
 
 ``header``


### PR DESCRIPTION
The 'Bearer' authentication type is one of HTTPie's built-in ones. Let's have tests for it, and silently deprecate the 'Token' authentication that this plugin used to provide.